### PR TITLE
feat: secure admin login

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -43,6 +43,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "backend.middleware.AdminTicketMiddleware",  # защита реального ADMIN_URL
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -106,6 +107,13 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# URL страницы логина (используется декоратором @login_required)
+LOGIN_URL = "/accounts/login/"
+# После успешного входа перенаправляем на генерацию одноразовой ссылки
+LOGIN_REDIRECT_URL = "/admin-link/"
+# После выхода отправляем обратно на форму входа
+LOGOUT_REDIRECT_URL = LOGIN_URL
 
 # === DRF ===
 REST_FRAMEWORK = {

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -44,6 +44,9 @@ urlpatterns = [
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 
+    # Аутентификация (login/logout)
+    path("accounts/", include("django.contrib.auth.urls")),
+
     # Одноразовые ссылки на админку
     path("admin-link/", create_admin_link, name="create-admin-link"),        # отдать одноразовый URL (только staff)
     path("admin-ticket/<str:token>/", use_admin_link, name="use-admin-link"),# перейти по одноразовому URL

--- a/backend/core/templates/registration/login.html
+++ b/backend/core/templates/registration/login.html
@@ -1,0 +1,17 @@
+<h2>Вход</h2>
+{% if form.errors %}
+<p style="color:red">Неверный логин или пароль</p>
+{% endif %}
+<form method="post" action="{% url 'login' %}">
+  {% csrf_token %}
+  <p>
+    <label for="{{ form.username.id_for_label }}">Логин:</label>
+    {{ form.username }}
+  </p>
+  <p>
+    <label for="{{ form.password.id_for_label }}">Пароль:</label>
+    {{ form.password }}
+  </p>
+  {% if next %}<input type="hidden" name="next" value="{{ next }}">{% endif %}
+  <button type="submit">Войти</button>
+</form>


### PR DESCRIPTION
## Summary
- clarify login/logout paths and redirects for admin access
- use `reverse` for admin ticket URLs and final admin redirect
- improve login template with explicit fields and next param

## Testing
- `python manage.py test`
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a0944f3074833188a90e1c2bbe2a48