### PR TITLE
Исправлена отправка писем через SMTP Яндекс

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -144,19 +144,18 @@ SPECTACULAR_SETTINGS = {
 }
 
 # === ПОЧТА ===
-# Dev: вывод в консоль; Прод: переопредели EMAIL_BACKEND и креды из окружения
-EMAIL_BACKEND = os.getenv("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@example.com")
+# Конфигурация SMTP для отправки писем (по умолчанию — Яндекс)
+EMAIL_BACKEND = os.getenv(
+    "EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
+)
+EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.yandex.ru")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "0") == "1"
+EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "1") == "1"
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER or "noreply@example.com")
 NOTIFY_TO = os.getenv("NOTIFY_TO", "izotovlife@yandex.ru")
-
-# Пример для прод-отправки через SMTP (задай переменные окружения и раскомментируй):
-# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-# EMAIL_HOST = os.getenv("EMAIL_HOST", "smtp.yandex.ru")
-# EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
-# EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
-# EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
-# EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "0") == "1"
-# EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "1") == "1"
 
 # === БЕЗОПАСНОСТЬ (включится автоматически, когда DEBUG=0) ===
 if not DEBUG:

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -46,19 +46,15 @@ class LeadViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
 
     def perform_create(self, serializer):
         lead = serializer.save()
-        # отправка уведомления (в dev можно не настраивать SMTP —
-        # письма просто пропустим благодаря fail_silently=True)
-        try:
-            send_mail(
-                subject="Новая заявка с сайта",
-                message=(
-                    f"Имя: {lead.name}\n"
-                    f"Контакт: {lead.contact}\n"
-                    f"Сообщение: {lead.message}"
-                ),
-                from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@example.com"),
-                recipient_list=[getattr(settings, "NOTIFY_TO", "izotovlife@yandex.ru")],
-                fail_silently=True,
-            )
-        except Exception:
-            pass
+        # отправка уведомления на email
+        send_mail(
+            subject="Новая заявка с сайта",
+            message=(
+                f"Имя: {lead.name}\n"
+                f"Контакт: {lead.contact}\n"
+                f"Сообщение: {lead.message}"
+            ),
+            from_email=getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@example.com"),
+            recipient_list=[getattr(settings, "NOTIFY_TO", "izotovlife@yandex.ru")],
+            fail_silently=False,
+        )

--- a/frontend/src/components/OrderModal.css
+++ b/frontend/src/components/OrderModal.css
@@ -7,15 +7,28 @@
   width:100%; max-width:560px; background:#fff; border:1px solid var(--border);
   border-radius:18px; box-shadow:var(--shadow); position:relative; padding:20px;
 }
-.modal h3{ margin:0 0 10px }
+.modal h3{
+  margin:0 0 10px;
+  color:var(--primary);
+}
 .modal-form{ display:grid; gap:12px }
 .modal-form input, .modal-form textarea{
   width:100%; border:1px solid var(--border); border-radius:12px; padding:12px 14px; font:inherit;
+}
+.modal-form input:focus, .modal-form textarea:focus{
+  outline:none;
+  border-color:var(--primary);
+  box-shadow:0 0 0 2px var(--primary-50);
 }
 .hint{ font-size:14px; margin-top:4px }
 .hint.ok{ color:#059669 }
 .hint.err{ color:#dc2626 }
 .modal-close{
-  position:absolute; top:8px; right:10px; background:#fff; border:1px solid var(--border);
+  position:absolute; top:8px; right:10px; background:#fff; border:1px solid var(--primary);
   width:34px; height:34px; border-radius:10px; font-size:20px; line-height:1; cursor:pointer;
+  color:var(--primary);
+}
+.modal-close:hover{
+  background:var(--primary);
+  color:#fff;
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -2,9 +2,9 @@
   --bg:#ffffff;
   --text:#1e1e20;
   --muted:#6b7280;
-  --primary:#6d28d9;        /* фиолетовый */
-  --primary-600:#5b21b6;
-  --primary-50:#f5f3ff;
+  --primary:#004aad;        /* синий */
+  --primary-600:#003080;
+  --primary-50:#e0e8ff;
   --card:#ffffff;
   --border:#e5e7eb;
   --shadow:0 10px 25px rgba(0,0,0,.06);
@@ -39,7 +39,7 @@ img{max-width:100%; display:block}
   color:#fff; border:none; border-radius:12px; cursor:pointer;
   font-weight:600; letter-spacing:.2px;
   transition:transform .08s ease, box-shadow .2s ease, background .2s ease;
-  box-shadow: 0 6px 18px rgba(109,40,217,.25);
+  box-shadow: 0 6px 18px rgba(0,74,173,.25);
 }
 .btn:hover{ background:var(--primary-600) }
 .btn:active{ transform:translateY(1px) }


### PR DESCRIPTION
## Summary
- configure SMTP defaults for Yandex and expose mail settings via env vars
- send lead notifications without suppressing errors

## Testing
- `npm test -- --watchAll=false` (fails: SyntaxError: Cannot use import statement outside a module)
- `python backend/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a3fa295a148331927061fee852bc2d