### PR TITLE
Use SVG logo and refresh header/footer

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="120" y2="120" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00e0ff"/>
+      <stop offset="1" stop-color="#0056d6"/>
+    </linearGradient>
+  </defs>
+  <path fill="none" stroke="url(#g)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"
+        d="M60 8l46 26v52l-46 26-46-26V34z"/>
+  <path fill="none" stroke="url(#g)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"
+        d="M40 40h40l-40 40h40"/>
+</svg>

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -1,28 +1,27 @@
 .site-footer{
-  margin-top:56px; border-top:1px solid var(--border); background:var(--primary-50);
+  margin-top:56px;
+  background:linear-gradient(90deg,#1e293b,#0f172a);
+  color:#fff;
 }
 .footer-grid{
-  display:grid; gap:24px; padding-block:26px;
+  display:grid;
+  gap:24px;
+  padding-block:26px;
 }
 @media (min-width:760px){ .footer-grid{ grid-template-columns:2fr 1fr 1fr } }
 
-/* Логотип футера — прозрачный, без подложек */
 .footer-brand{ display:flex; flex-direction:column; gap:10px }
-.footer-brand-img{
-  display:block;
-  background: transparent !important;
-  border: 0 !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  object-fit: contain;
-}
+.footer-brand-img{ display:block; object-fit:contain }
+.footer-brand-title{ font-weight:700; font-size:20px; color:#fff }
 
 .list{ list-style:none; padding:0; margin:0 }
 .list li{ margin:8px 0 }
-.list a{ color:var(--text) }
-.list a:hover{ color:var(--primary) }
+.list a{ color:#e5e7eb }
+.list a:hover{ color:#fff }
 
 .footbar{
-  border-top:1px dashed var(--border); font-size:14px; color:var(--muted);
+  border-top:1px solid rgba(255,255,255,0.1);
+  font-size:14px;
+  color:#94a3b8;
   padding:10px 0;
 }

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,6 +1,6 @@
 // Footer.js
 // frontend/src/components/Footer.js
-// Футер сайта, логотип берётся из /public/logo192.png и /public/logo512.png
+// Футер сайта с логотипом из public/logo.svg
 import React from "react";
 import "./Footer.css";
 
@@ -11,13 +11,13 @@ export default function Footer(){
         <div className="footer-brand">
           <img
             className="footer-brand-img"
-            src="/logo192.png"
-            srcSet="/logo192.png 1x, /logo512.png 2x"
+            src="/logo.svg"
             alt="IZOTOVLIFE"
             height="32"
             width="auto"
             decoding="async"
           />
+          <span className="footer-brand-title">IZOTOVLIFE</span>
           <p className="muted">
             Разработка сайтов и автоматизация для вашего бизнеса.
           </p>

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -1,11 +1,14 @@
 /* ================= */
 /* HEADER            */
 /* ================= */
+
 .site-header {
-  position: sticky; top:0; z-index:50;
-  background: rgba(255,255,255,.8);
-  backdrop-filter: saturate(160%) blur(10px);
-  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: linear-gradient(90deg, #0f172a, #1e293b);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
 }
 
 .header-row {
@@ -13,29 +16,36 @@
   padding-block:12px;
 }
 
-.brand { display:inline-flex; align-items:center; text-decoration:none }
+.brand { display:inline-flex; align-items:center; gap:8px; text-decoration:none }
 
-/* Логотип — без подложек/рамок/теней, перекрашиваем в синий кнопки */
 .brand-img {
   display:block;
-  background: transparent !important;
-  border: 0 !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  object-fit: contain;
+  object-fit:contain;
+}
 
-  /* 🔹 Перекрашивание PNG в #0056D6 */
-  filter: brightness(0) saturate(100%) invert(17%) sepia(90%) saturate(5329%) hue-rotate(215deg) brightness(92%) contrast(101%);
+.brand-title{
+  font-weight:700;
+  color:#fff;
+  font-size:20px;
 }
 
 /* Навигация */
 .nav { display:flex; gap:26px; align-items:center }
 .nav-link {
-  padding:8px 2px; position:relative; font-weight:600; color:var(--text)
+  padding:8px 2px;
+  position:relative;
+  font-weight:600;
+  color:#fff;
 }
 .nav-link.active { color:var(--primary) }
 .nav-link::after {
-  content:""; position:absolute; left:0; bottom:-6px; height:2px; width:0; background:var(--primary);
+  content:"";
+  position:absolute;
+  left:0;
+  bottom:-6px;
+  height:2px;
+  width:0;
+  background:var(--primary);
   transition:width .2s ease;
 }
 .nav-link:hover::after,
@@ -43,51 +53,21 @@
 
 /* Бургер */
 .burger { display:inline-flex; flex-direction:column; gap:5px; background:none; border:0; cursor:pointer }
-.burger span { width:22px; height:2px; background:var(--text); border-radius:2px }
+.burger span { width:22px; height:2px; background:#fff; border-radius:2px }
 @media (min-width:900px){ .burger{ display:none } }
 
 @media (max-width:899px){
   .nav {
-    position:fixed; inset:64px 0 auto 0; background:#fff;
-    border-bottom:1px solid var(--border);
-    transform:translateY(-120%); transition:transform .25s ease;
-    padding:16px 20px; gap:14px; flex-direction:column; align-items:flex-start;
+    position:fixed;
+    inset:64px 0 auto 0;
+    background:linear-gradient(90deg,#0f172a,#1e293b);
+    border-bottom:1px solid rgba(255,255,255,0.1);
+    transform:translateY(-120%);
+    transition:transform .25s ease;
+    padding:16px 20px;
+    gap:14px;
+    flex-direction:column;
+    align-items:flex-start;
   }
   .nav.open { transform:translateY(0) }
-}
-
-
-/* ================= */
-/* FOOTER            */
-/* ================= */
-.site-footer {
-  margin-top:56px; border-top:1px solid var(--border); background:var(--primary-50);
-}
-.footer-grid {
-  display:grid; gap:24px; padding-block:26px;
-}
-@media (min-width:760px){ .footer-grid{ grid-template-columns:2fr 1fr 1fr } }
-
-/* Логотип футера — прозрачный, без подложек */
-.footer-brand { display:flex; flex-direction:column; gap:10px }
-.footer-brand-img {
-  display:block;
-  background: transparent !important;
-  border: 0 !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  object-fit: contain;
-
-  /* 🔹 Перекрашивание PNG в #0056D6 */
-  filter: brightness(0) saturate(100%) invert(17%) sepia(90%) saturate(5329%) hue-rotate(215deg) brightness(92%) contrast(101%);
-}
-
-.list { list-style:none; padding:0; margin:0 }
-.list li { margin:8px 0 }
-.list a { color:var(--text) }
-.list a:hover { color:var(--primary) }
-
-.footbar {
-  border-top:1px dashed var(--border); font-size:14px; color:var(--muted);
-  padding:10px 0;
 }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,6 +1,6 @@
 // frontend/src/components/Header.js
 
-// Шапка сайта, логотип берётся из /public/logo192.png и /public/logo512.png
+// Шапка сайта с логотипом из public/logo.svg
 import React, { useState } from "react";
 import { NavLink, Link } from "react-router-dom";
 import "./Header.css";
@@ -14,13 +14,13 @@ export default function Header() {
         <Link to="/" className="brand" onClick={() => setOpen(false)}>
           <img
             className="brand-img"
-            src="/logo192.png"
-            srcSet="/logo192.png 1x, /logo512.png 2x"
+            src="/logo.svg"
             alt="IZOTOVLIFE"
-            height="36"            // чуть меньше, как просили
+            height="36"
             width="auto"
             decoding="async"
           />
+          <span className="brand-title">IZOTOVLIFE</span>
         </Link>
 
         <button


### PR DESCRIPTION
## Summary
- Replace PNG logo with vector `logo.svg`
- Restyle header and footer with dark gradient and brand title

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in axios)*
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a667e4688331b245016a0340ae10