### PR TITLE
Add dark themed landing page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,9 @@
 // C:\Users\ASUS Vivobook\PycharmProjects\izotoff.ru\business_site\frontend\src\App.js
 import React from "react";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import Home from "./pages/Home";
 import Services from "./pages/Services";
 import Portfolio from "./pages/Portfolio";
 import Testimonials from "./pages/Testimonials";
@@ -14,7 +15,7 @@ export default function App(){
       <Header/>
       <main>
         <Routes>
-          <Route path="/" element={<Navigate to="/services" replace/>}/>
+          <Route path="/" element={<Home/>}/>
           <Route path="/services" element={<Services/>}/>
           <Route path="/portfolio" element={<Portfolio/>}/>
           <Route path="/testimonials" element={<Testimonials/>}/>

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -1,0 +1,24 @@
+.home-hero{
+  background:radial-gradient(circle at top,#1e293b,#0f172a);
+  padding:80px 0;
+  text-align:center;
+  color:#fff;
+}
+
+.home-logo{
+  width:120px;
+  margin:0 auto 20px;
+}
+
+.home-title{
+  font-size:clamp(32px,5vw,56px);
+  margin:0 0 12px;
+  color:#fff;
+}
+
+.home-tagline{
+  font-size:20px;
+  color:var(--muted);
+  margin:0;
+}
+

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,0 +1,19 @@
+// frontend/src/pages/Home.js
+// Главная страница с героем и логотипом
+import React from "react";
+import "./Home.css";
+
+export default function Home(){
+  return (
+    <section className="home-hero">
+      <div className="container center">
+        <div className="home-content">
+          <img src="/logo.svg" alt="IZOTOVLIFE" className="home-logo" />
+          <h1 className="home-title">IZOTOVLIFE</h1>
+          <p className="home-tagline">Digital solutions crafted with passion</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,13 +1,13 @@
 :root{
-  --bg:#ffffff;
-  --text:#1e1e20;
-  --muted:#6b7280;
-  --primary:#004aad;        /* синий */
-  --primary-600:#003080;
-  --primary-50:#e0e8ff;
-  --card:#ffffff;
-  --border:#e5e7eb;
-  --shadow:0 10px 25px rgba(0,0,0,.06);
+  --bg:#0f172a;
+  --text:#f1f5f9;
+  --muted:#94a3b8;
+  --primary:#22d3ee;        /* cyan */
+  --primary-600:#0891b2;
+  --primary-50:#083344;
+  --card:#1e293b;
+  --border:#334155;
+  --shadow:0 10px 25px rgba(0,0,0,.5);
   --radius:16px;
   --container:1160px;
 }


### PR DESCRIPTION
## Summary
- switch global styles to a dark palette matching the IZOTOVLIFE logo
- add home page with hero section displaying logo and tagline
- wire up new home route in React app

## Testing
- `pytest` *(fails: fixture 'client' not found)*
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d4b8f0b483319ad45000d1205d0b