### PR TITLE
Add portfolio page and responsive navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,21 +6,28 @@ import Footer from "./components/Footer";
 import Home from "./pages/Home";
 import ServiceListPage from "./pages/ServiceListPage";
 import ContactsPage from "./pages/ContactsPage";
+import PortfolioPage from "./pages/PortfolioPage";
+import AdminRedirect from "./pages/AdminRedirect.jsx";
+import { OrderModalProvider } from "./OrderModalContext";
 import "./theme.css";
 
 export default function App(){
   return (
     <BrowserRouter>
-      <Header/>
-      <main>
-        <Routes>
-          <Route path="/" element={<Home/>}/>
-          <Route path="/services" element={<ServiceListPage/>}/>
-          <Route path="/contacts" element={<ContactsPage/>}/>
-          <Route path="*" element={<div className="container">Страница не найдена</div>} />
-        </Routes>
-      </main>
-      <Footer/>
+      <OrderModalProvider>
+        <Header/>
+        <main>
+          <Routes>
+            <Route path="/" element={<Home/>}/>
+            <Route path="/services" element={<ServiceListPage/>}/>
+            <Route path="/portfolio" element={<PortfolioPage/>}/>
+            <Route path="/contacts" element={<ContactsPage/>}/>
+            <Route path="/admin" element={<AdminRedirect/>} />
+            <Route path="*" element={<div className="container">Страница не найдена</div>} />
+          </Routes>
+        </main>
+        <Footer/>
+      </OrderModalProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/OrderModalContext.js
+++ b/frontend/src/OrderModalContext.js
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState } from "react";
+import OrderModal from "./components/OrderModal";
+
+const OrderModalContext = createContext(null);
+
+export function OrderModalProvider({ children }) {
+  const [state, setState] = useState({ open: false, preset: null, serviceId: null });
+
+  const openModal = (preset = "site", serviceId = null) => {
+    setState({ open: true, preset, serviceId });
+  };
+
+  const closeModal = () => setState((s) => ({ ...s, open: false }));
+
+  return (
+    <OrderModalContext.Provider value={{ openModal }}>
+      {children}
+      <OrderModal
+        open={state.open}
+        onClose={closeModal}
+        preset={state.preset}
+        serviceId={state.serviceId}
+      />
+    </OrderModalContext.Provider>
+  );
+}
+
+export function useOrderModal() {
+  const ctx = useContext(OrderModalContext);
+  if (!ctx) throw new Error("useOrderModal must be used within OrderModalProvider");
+  return ctx;
+}
+

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -19,6 +19,10 @@
 .list a{ color:#e5e7eb }
 .list a:hover{ color:#fff }
 
+.social{ display:flex; gap:8px; margin-top:8px }
+.social a{ color:#e5e7eb }
+.social a:hover{ color:#fff }
+
 .footbar{
   border-top:1px solid rgba(255,255,255,0.1);
   font-size:14px;

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -1,28 +1,39 @@
-import React, { useState } from "react";
-import OrderModal from "./OrderModal";
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { useOrderModal } from "../OrderModalContext";
 import "./Footer.css";
 
 export default function Footer() {
-  const [modal, setModal] = useState(false);
+  const { openModal } = useOrderModal();
+  const year = new Date().getFullYear();
 
   return (
     <footer className="site-footer">
-      <div className="container footer-content">
-        <img src="/logo.png" alt="IZOTOVLIFE" className="site-logo" />
-        <div className="contacts">
-          <a href="tel:+79999999999">+7 (999) 999-99-99</a>
+      <div className="container footer-grid">
+        <div className="footer-brand">
+          <img src="/logo.svg" alt="IZOTOVLIFE" className="footer-brand-img" />
+          <span className="footer-brand-title">IZOTOVLIFE</span>
+        </div>
+
+        <ul className="list">
+          <li><NavLink to="/services">Услуги</NavLink></li>
+          <li><NavLink to="/portfolio">Портфолио</NavLink></li>
+          <li><NavLink to="/contacts">Контакты</NavLink></li>
+        </ul>
+
+        <div className="list">
+          <p>Москва, м. Орехово</p>
+          <a href="tel:+79267769268">+7 (926) 776-92-68</a>
           <a href="mailto:izotovlife@yandex.ru">izotovlife@yandex.ru</a>
           <div className="social">
-            <a href="https://vk.com" target="_blank" rel="noreferrer">VK</a>
-            <a href="https://ok.ru" target="_blank" rel="noreferrer">OK</a>
-            <a href="https://t.me" target="_blank" rel="noreferrer">TG</a>
+            <a href="https://m.vk.com/itactprint" target="_blank" rel="noreferrer">VK</a>
+            <a href="https://ok.ru/itactprint" target="_blank" rel="noreferrer">OK</a>
+            <a href="https://t.me/copyzongroup" target="_blank" rel="noreferrer">TG</a>
           </div>
-          <button className="btn" onClick={() => setModal(true)}>
-            Заказать услугу
-          </button>
+          <button className="btn" onClick={() => openModal("footer")}>Заказать услугу</button>
         </div>
       </div>
-      <OrderModal open={modal} onClose={() => setModal(false)} preset="footer" />
+      <div className="container footbar">© {year} IZOTOVLIFE</div>
     </footer>
   );
 }

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,27 +1,62 @@
 import React, { useState } from "react";
-import { Link } from "react-router-dom";
-import OrderModal from "./OrderModal";
+import { NavLink } from "react-router-dom";
+import { useOrderModal } from "../OrderModalContext";
 import "./Header.css";
 
 export default function Header() {
-  const [modal, setModal] = useState(false);
+  const [open, setOpen] = useState(false);
+  const { openModal } = useOrderModal();
+
+  const closeMenu = () => setOpen(false);
 
   return (
     <header className="site-header">
       <div className="container header-row">
-        <Link to="/" className="brand">
-          <img src="/logo.png" alt="IZOTOVLIFE" className="site-logo" />
-        </Link>
-        <div className="header-actions">
-          <button className="btn" onClick={() => setModal(true)}>
-            Заказать услугу
-          </button>
-          <button className="btn" onClick={() => setModal(true)}>
-            Заказать услугу
-          </button>
-        </div>
+        <NavLink to="/" className="brand" onClick={closeMenu}>
+          <img src="/logo.svg" alt="IZOTOVLIFE" className="brand-img" />
+          <span className="brand-title">IZOTOVLIFE</span>
+        </NavLink>
+
+        <nav className={`nav ${open ? "open" : ""}`}>
+          <NavLink
+            to="/services"
+            className={({ isActive }) =>
+              `nav-link${isActive ? " active" : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Услуги
+          </NavLink>
+          <NavLink
+            to="/portfolio"
+            className={({ isActive }) =>
+              `nav-link${isActive ? " active" : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Портфолио
+          </NavLink>
+          <NavLink
+            to="/contacts"
+            className={({ isActive }) =>
+              `nav-link${isActive ? " active" : ""}`
+            }
+            onClick={closeMenu}
+          >
+            Контакты
+          </NavLink>
+        </nav>
+
+        <button className="btn" onClick={() => openModal("header") }>
+          Заказать услугу
+        </button>
+
+        <button className="burger" onClick={() => setOpen(!open)}>
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
       </div>
-      <OrderModal open={modal} onClose={() => setModal(false)} preset="header" />
     </header>
   );
 }

--- a/frontend/src/components/OrderModal.js
+++ b/frontend/src/components/OrderModal.js
@@ -26,7 +26,11 @@ export default function OrderModal({ open, onClose, preset, serviceId }) {
 
   const submit = async (e) => {
     e.preventDefault();
-    if (form.company) return; // honeypot
+    if (form.company) return; // honeypот
+    if (!form.name || (!form.phone && !form.email) || !form.consent) {
+      setStatus("fill");
+      return;
+    }
     setStatus("loading");
     try {
       await api.post(`/leads/?src=${preset || "site"}`, {
@@ -61,6 +65,7 @@ export default function OrderModal({ open, onClose, preset, serviceId }) {
           <input
             placeholder="Ваше имя"
             value={form.name}
+            required
             onChange={(e) => setForm({ ...form, name: e.target.value })}
           />
           <input
@@ -108,6 +113,9 @@ export default function OrderModal({ open, onClose, preset, serviceId }) {
           </button>
           {status === "ok" && <div className="hint ok">Заявка отправлена</div>}
           {status === "err" && <div className="hint err">Ошибка отправки</div>}
+          {status === "fill" && (
+            <div className="hint err">Заполните обязательные поля и дайте согласие</div>
+          )}
         </form>
         <button className="modal-close" onClick={onClose} aria-label="Закрыть">
           ×

--- a/frontend/src/pages/ContactsPage.js
+++ b/frontend/src/pages/ContactsPage.js
@@ -1,19 +1,19 @@
-import React, { useState } from "react";
-import OrderModal from "../components/OrderModal";
+import React from "react";
+import { useOrderModal } from "../OrderModalContext";
 
 export default function ContactsPage() {
-  const [open, setOpen] = useState(false);
+  const { openModal } = useOrderModal();
   return (
     <div className="container">
       <h1>Контакты</h1>
-      <p>Телефон: <a href="tel:+79999999999">+7 (999) 999-99-99</a></p>
+      <p>Телефон: <a href="tel:+79267769268">+7 (926) 776-92-68</a></p>
       <p>Email: <a href="mailto:izotovlife@yandex.ru">izotovlife@yandex.ru</a></p>
+      <p>Адрес: Москва, м. Орехово</p>
       <div>
-        <button className="btn" onClick={() => setOpen(true)}>
+        <button className="btn" onClick={() => openModal("page") }>
           Заказать услугу
         </button>
       </div>
-      <OrderModal open={open} onClose={() => setOpen(false)} preset="page" />
     </div>
   );
 }

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -5,11 +5,6 @@
   color:#fff;
 }
 
-.home-logo{
-  width:120px;
-  margin:0 auto 20px;
-}
-
 .home-title{
   font-size:clamp(32px,5vw,56px);
   margin:0 0 12px;
@@ -21,4 +16,6 @@
   color:var(--muted);
   margin:0;
 }
+
+.home-actions{ margin-top:24px }
 

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,16 +1,24 @@
 // frontend/src/pages/Home.js
 // Главная страница с героем и логотипом
 import React from "react";
+import { useOrderModal } from "../OrderModalContext";
 import "./Home.css";
 
-export default function Home(){
+export default function Home() {
+  const { openModal } = useOrderModal();
   return (
     <section className="home-hero">
       <div className="container center">
         <div className="home-content">
-          <img src="/logo.svg" alt="IZOTOVLIFE" className="home-logo" />
-          <h1 className="home-title">IZOTOVLIFE</h1>
-          <p className="home-tagline">Digital solutions crafted with passion</p>
+          <h1 className="home-title">Александр Изотов</h1>
+          <p className="home-tagline">
+            Администрирование сайтов, контент и SMM
+          </p>
+          <div className="home-actions">
+            <button className="btn" onClick={() => openModal("home") }>
+              Оставить заявку
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/PortfolioPage.js
+++ b/frontend/src/pages/PortfolioPage.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import api from "../Api";
+
+export default function PortfolioPage() {
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    api
+      .get("/portfolio/")
+      .then((res) => setItems(res.data))
+      .catch(() => setItems([]));
+  }, []);
+
+  return (
+    <div className="container">
+      <h1>Портфолио</h1>
+      <div className="grid cols-3">
+        {items.map((item) => (
+          <div key={item.id} className="card">
+            {item.image && <img src={item.image} alt={item.title} />}
+            <h3>{item.title}</h3>
+            {item.description && <p className="muted">{item.description}</p>}
+            {item.link && (
+              <a href={item.link} target="_blank" rel="noreferrer">
+                Подробнее
+              </a>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ServiceListPage.js
+++ b/frontend/src/pages/ServiceListPage.js
@@ -1,36 +1,47 @@
 import React, { useEffect, useState } from "react";
-import OrderModal from "../components/OrderModal";
 import api from "../Api";
+import { useOrderModal } from "../OrderModalContext";
 
 export default function ServiceListPage() {
   const [services, setServices] = useState([]);
-  const [active, setActive] = useState(null);
+  const { openModal } = useOrderModal();
+
+  const defaults = [
+    { id: 1, title: "Администрирование сайтов" },
+    { id: 2, title: "Контент‑менеджмент" },
+    { id: 3, title: "SMM и ведение соцсетей" },
+    { id: 4, title: "Обработка фото и видео" },
+    { id: 5, title: "Работа с маркетплейсами" },
+    { id: 6, title: "Управление отзывами" },
+    { id: 7, title: "SEO и реклама" },
+    { id: 8, title: "Консультации по принтерам" },
+  ];
 
   useEffect(() => {
-    api.get("/services/").then((res) => setServices(res.data));
+    api
+      .get("/services/")
+      .then((res) => {
+        if (res.data && res.data.length) setServices(res.data);
+        else setServices(defaults);
+      })
+      .catch(() => setServices(defaults));
   }, []);
 
   return (
     <div className="container">
       <h1>Услуги</h1>
-      <div className="services-grid">
+      <div className="grid cols-2">
         {services.map((s) => (
-          <div key={s.id} className="service-card">
+          <div key={s.id} className="card service-card">
             <h3>{s.title}</h3>
             {s.short && <p>{s.short}</p>}
             {s.price_from && <p>от {s.price_from} ₽</p>}
-            <button className="btn" onClick={() => setActive(s.id)}>
+            <button className="btn" onClick={() => openModal("page", s.id)}>
               Заказать услугу
             </button>
           </div>
         ))}
       </div>
-      <OrderModal
-        open={active !== null}
-        onClose={() => setActive(null)}
-        preset="page"
-        serviceId={active}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- centralize order modal so header, footer, and pages share a single contact form
- validate required fields before submitting a lead
- wire global modal into header navigation to avoid duplicated forms

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab10ce03fc8331956d89d25ac11d54